### PR TITLE
Install VIM and Valgrind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN git clone -b v1.5 https://github.com/KDE/clazy.git /var/tmp/clazy
 RUN cd /var/tmp/clazy; cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 RUN make -C /var/tmp/clazy all install
 
+RUN apt-get install -y valgrind
+RUN apt-get install -y vim
 RUN apt-get install -y curl
 RUN apt-get install -y python3.6 python3-websockets
 


### PR DESCRIPTION
Adding VIM to the VM to help people which /bin/bash into the running docker.
Addind Valgrind to include in the unit-tests a memory check.